### PR TITLE
Gingerbread

### DIFF
--- a/su/su.c
+++ b/su/su.c
@@ -24,7 +24,7 @@
 
 #include <sqlite3.h>
 
-extern char* mktemp(char*); /* mktemp links okay*/
+//extern char* mktemp(char*); /* mktemp links okay*/
 
 #include "su.h"
 

--- a/su/su.c
+++ b/su/su.c
@@ -24,7 +24,7 @@
 
 #include <sqlite3.h>
 
-extern char* _mktemp(char*); /* mktemp doesn't link right.  Don't ask me why. */
+extern char* mktemp(char*); /* mktemp links okay*/
 
 #include "su.h"
 
@@ -146,7 +146,7 @@ static int socket_create_temp()
         memset(&sun, 0, sizeof(sun));
         sun.sun_family = AF_LOCAL;
         strcpy(socket_path_buf, socket_path_template);
-        socket_path = _mktemp(socket_path_buf);
+        socket_path = mktemp(socket_path_buf);
         snprintf(sun.sun_path, sizeof(sun.sun_path), "%s", socket_path);
 
         if (bind(fd, (struct sockaddr*)&sun, sizeof(sun)) < 0) {


### PR DESCRIPTION
Hi, The su binary as linked doesnt work well with the Nook color Honeycomb build. Although this build is not really standard, but I think it represents the working state of the bionic libc, which do not have the _mktemp definition anymore.

These changes are tested against a generic build of the CM srouces from the gingerbread branch. Please consider including them for maxium compatibility with future android releases.
